### PR TITLE
Fix StaticSMOTE pipeline API

### DIFF
--- a/multi_imbalance/datasets/_data_loader.py
+++ b/multi_imbalance/datasets/_data_loader.py
@@ -24,7 +24,7 @@ from os.path import join, isfile
 
 import numpy as np
 
-from sklearn.datasets.base import Bunch
+from sklearn.datasets._base import Bunch
 
 PRE_FILENAME = 'x'
 POST_FILENAME = 'data.npz'

--- a/multi_imbalance/ensemble/tests/test_mrbbagging.py
+++ b/multi_imbalance/ensemble/tests/test_mrbbagging.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 
-from sklearn.tree import tree
+from sklearn.tree import DecisionTreeClassifier
 
 from multi_imbalance.ensemble.mrbbagging import MRBBagging
 import numpy as np
@@ -36,39 +36,39 @@ y_test = np.array([0, 0, 0, 0])
 
 class TestMRBBagging(unittest.TestCase):
     def test_api(self):
-        mrbbagging = MRBBagging(1, tree.DecisionTreeClassifier(random_state=0), random_state=0)
+        mrbbagging = MRBBagging(1, DecisionTreeClassifier(random_state=0), random_state=0)
         mrbbagging.fit(X_train, y_train)
         y_pred = mrbbagging.predict(X_test)
         assert all(y_pred == y_test)
 
     def test_api_multiple_trees(self):
-        mrbbagging = MRBBagging(5, tree.DecisionTreeClassifier(random_state=0), random_state=0)
+        mrbbagging = MRBBagging(5, DecisionTreeClassifier(random_state=0), random_state=0)
         mrbbagging.fit(X_train, y_train)
         y_pred = mrbbagging.predict(X_test)
         assert all(y_pred == y_test)
 
     def test_api_with_feature_selection(self):
-        mrbbagging = MRBBagging(1, tree.DecisionTreeClassifier(random_state=0), feature_selection=True, random_state=0)
+        mrbbagging = MRBBagging(1, DecisionTreeClassifier(random_state=0), feature_selection=True, random_state=0)
         mrbbagging.fit(X_train, y_train)
         y_pred = mrbbagging.predict(X_test)
         assert all(y_pred == y_test)
 
     def test_api_with_random_feature_selection(self):
-        mrbbagging = MRBBagging(1, tree.DecisionTreeClassifier(random_state=0), feature_selection=True, random_fs=True,
+        mrbbagging = MRBBagging(1, DecisionTreeClassifier(random_state=0), feature_selection=True, random_fs=True,
                                 random_state=0)
         mrbbagging.fit(X_train, y_train)
         y_pred = mrbbagging.predict(X_test)
         assert all(y_pred == y_test)
 
     def test_api_with_feature_selection_sqrt_features(self):
-        mrbbagging = MRBBagging(1, tree.DecisionTreeClassifier(random_state=0), feature_selection=True,
+        mrbbagging = MRBBagging(1, DecisionTreeClassifier(random_state=0), feature_selection=True,
                                 half_features=False, random_state=0)
         mrbbagging.fit(X_train, y_train)
         y_pred = mrbbagging.predict(X_test)
         assert all(y_pred == y_test)
 
     def test__group_data(self):
-        mrbbagging = MRBBagging(1, tree.DecisionTreeClassifier())
+        mrbbagging = MRBBagging(1, DecisionTreeClassifier())
         x = [[1, 1, 1], [2, 2, 2], [3, 3, 3]]
         y = ["A", "B", "C"]
         classes, grouped_data = mrbbagging._group_data(x, y)
@@ -76,7 +76,7 @@ class TestMRBBagging(unittest.TestCase):
         self.assertEqual(grouped_data, {'C': [[[3, 3, 3], 'C']], 'A': [[[1, 1, 1], 'A']], 'B': [[[2, 2, 2], 'B']]})
 
     def test__group_data_with_none(self):
-        mrbbagging = MRBBagging(1, tree.DecisionTreeClassifier())
+        mrbbagging = MRBBagging(1, DecisionTreeClassifier())
         x = [[1, 1, 1], [2, 2, 2], [3, 3, 3]]
         y = ["A", None, "C"]
         with self.assertRaises(AssertionError):
@@ -95,7 +95,7 @@ class TestMRBBagging(unittest.TestCase):
 
     def test_with_invalid_k(self):
         with self.assertRaises(AssertionError):
-            MRBBagging(0, tree.DecisionTreeClassifier())
+            MRBBagging(0, DecisionTreeClassifier())
 
 
 if __name__ == '__main__':

--- a/multi_imbalance/resampling/static_smote.py
+++ b/multi_imbalance/resampling/static_smote.py
@@ -2,9 +2,10 @@ from collections import Counter
 
 import numpy as np
 from imblearn.over_sampling import SMOTE
+from imblearn.base import BaseSampler
 
 
-class StaticSMOTE:
+class StaticSMOTE(BaseSampler):
     """
     Static SMOTE implementation:
 
@@ -13,9 +14,21 @@ class StaticSMOTE:
     procedure based on sensitivity for multi-class problems. Pattern Recognit. 44, 1821–1833
     (2011)
     """
+    def __init__(self):
+        super().__init__()
+        self._sampling_type = 'over-sampling'
 
-    # TODO add docstring
-    def fit_transform(self, X, y):
+    def _fit_resample(self, X, y):
+        """
+        Performs resampling
+
+        :param X:
+            two dimensional numpy array (number of samples x number of features) with float numbers
+        :param y:
+            one dimensional numpy array with labels for rows in X
+        :return:
+            Resampled X and y as numpy arrays
+        """
         cnt = Counter(y)
         min_class = min(cnt, key=cnt.get)
         X_original, y_original = X.copy(), y.copy()

--- a/multi_imbalance/resampling/tests/test_static_smote.py
+++ b/multi_imbalance/resampling/tests/test_static_smote.py
@@ -12,7 +12,7 @@ def test_static_smote():
 
     y = np.array([1] * 100 + [2] * 30 + [3] * 20)
     ssm = StaticSMOTE()
-    X_resampled, y_resampled = ssm.fit_transform(X, y)
+    X_resampled, y_resampled = ssm.fit_resample(X, y)
     cnt = Counter(y_resampled)
     assert cnt[1] == 100
     assert cnt[2] == 60

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(  # pragma no cover
     ],
     install_requires=[
         "numpy>=1.17.0",
-        "scikit-learn==0.21.3",
+        "scikit-learn>=0.21.3",
         "pandas>=0.25.1",
         "pytest>=5.1.2",
         "imbalanced-learn>=0.6.1",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(  # pragma no cover
     ],
     install_requires=[
         "numpy>=1.17.0",
-        "scikit-learn==0.21.3",
+        "scikit-learn>=0.22.1",
         "pandas>=0.25.1",
         "pytest>=5.1.2",
         "imbalanced-learn==0.6.1",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(  # pragma no cover
         "scikit-learn>=0.22.1",
         "pandas>=0.25.1",
         "pytest>=5.1.2",
-        "imbalanced-learn==0.6.1",
+        "imbalanced-learn>=0.6.1",
         "coverage>=5.1",
         "pytest-cov>=2.8.1",
         "IPython>=7.13.0",

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ setuptools.setup(  # pragma no cover
     ],
     install_requires=[
         "numpy>=1.17.0",
-        "scikit-learn>=0.21.3",
+        "scikit-learn==0.21.3",
         "pandas>=0.25.1",
         "pytest>=5.1.2",
-        "imbalanced-learn>=0.6.1",
+        "imbalanced-learn==0.6.1",
         "coverage>=5.1",
         "pytest-cov>=2.8.1",
         "IPython>=7.13.0",


### PR DESCRIPTION
This PR fixes Static SMOTE pipeline API, i.e. it enables to call fit_resample on that method and extends BaseSampler.