### PR TITLE
fixed UnicodeDecodeError during installation on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools # pragma no cover
 
-with open("README.md", "r") as fh:  # pragma no cover
+with open("README.md", "r", encoding='UTF8') as fh:  # pragma no cover
 
     long_description = fh.read()
 


### PR DESCRIPTION
I added a small modification (script 'setup.py')  which allowed me to install library without errors (Windows). Please check it out! ;)